### PR TITLE
Devhelp: Add manifest for org.gnome.Devhelp

### DIFF
--- a/org.gnome.Devhelp.json
+++ b/org.gnome.Devhelp.json
@@ -1,0 +1,43 @@
+{
+    "app-id": "org.gnome.Devhelp",
+    "runtime": "org.gnome.Sdk",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "devhelp",
+    "rename-icon": "devhelp",
+    "tags": ["nightly"],
+    "desktop-file-name-prefix": "(Nightly) ",
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* Wayland access */
+        "--socket=wayland",
+        /* Needed for dconf to work */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": ["/include", "/lib/pkgconfig",
+                "/share/pkgconfig", "/share/aclocal",
+                "/man", "/share/man"
+                "*.la", "*.a"],
+    "modules": [
+        {
+            "name": "devhelp",
+            "config-opts": ["--disable-man-pages"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/GNOME/devhelp.git",
+                    "branch": "master"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
In order for devhelp to show the generated doc from the runtime
libraries, gtk-doc is being included into the freedesktop SDK and
the modules are now built producing their documentation.