### PR TITLE
WIP: touch gitg

### DIFF
--- a/org.gnome.gitg.app
+++ b/org.gnome.gitg.app
@@ -1,3 +1,4 @@
+#update
 ID=org.gnome.gitg
 JSON=org.gnome.Gitg.json
 GITURL=https://gitlab.gnome.org/GNOME/gitg.git


### PR DESCRIPTION
trigger a new build

I added tag nightly and (Nightly) prefix

https://gitlab.gnome.org/GNOME/gitg/commit/251ff35f0197a0c309c95bf709157c4f61c5751d

But only see stable version on gnome-software:

![gitg on gnome-software](https://user-images.githubusercontent.com/220968/46784556-e8a33580-cd2e-11e8-83e4-9f734edfde5c.png)

For other software I see both versions:

![Builder on gnome-software](https://user-images.githubusercontent.com/220968/46784504-ab3ea800-cd2e-11e8-8949-7132fca03430.png)

flatpak search find both gitg versions:

```
$ flatpak search gitg
Application ID Version Branch Remotes            Description                   
org.gnome.gitg         stable flathub            Examinador de repositorios Git
org.gnome.gitg         master gnome-apps-nightly Examinador de repositorios Git
```

Am I missing some metadata or I need to manually trigger a new build